### PR TITLE
bump @oceanprotocol/contracts to v1.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@oceanprotocol/art": "^3.2.0",
-        "@oceanprotocol/contracts": "^1.1.7",
+        "@oceanprotocol/contracts": "^1.1.8",
         "@oceanprotocol/typographies": "^0.1.0",
         "@svgr/webpack": "^6.5.0",
         "axios": "^1.1.3",
@@ -2842,9 +2842,9 @@
       "integrity": "sha512-aUQtg4m5hJlQ0u8C29O9TXJWcAenO3G9vP+vf6LNFkpTDOCMycN/F0SzHS89VNrvGUha8oTDEg7FAkfZBPv2WA=="
     },
     "node_modules/@oceanprotocol/contracts": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.7.tgz",
-      "integrity": "sha512-Oe+oBRiu1dlco9PQ7eUYcTYi2Nua69S3TiSw62H46AIpwnFK8ORuO0Ny20No++KisBA9F+84b5lDn6kQy5Lt/Q=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.8.tgz",
+      "integrity": "sha512-I6xoADZpP/8EyN3VWZ+dLYv24DbJj3xzmSDcYv0FolXeAUF3FluzminL5AgQtAaoyUtlHl1D3ij1B++KupWcQQ=="
     },
     "node_modules/@oceanprotocol/typographies": {
       "version": "0.1.0",
@@ -8521,9 +8521,9 @@
       "integrity": "sha512-aUQtg4m5hJlQ0u8C29O9TXJWcAenO3G9vP+vf6LNFkpTDOCMycN/F0SzHS89VNrvGUha8oTDEg7FAkfZBPv2WA=="
     },
     "@oceanprotocol/contracts": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.7.tgz",
-      "integrity": "sha512-Oe+oBRiu1dlco9PQ7eUYcTYi2Nua69S3TiSw62H46AIpwnFK8ORuO0Ny20No++KisBA9F+84b5lDn6kQy5Lt/Q=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.8.tgz",
+      "integrity": "sha512-I6xoADZpP/8EyN3VWZ+dLYv24DbJj3xzmSDcYv0FolXeAUF3FluzminL5AgQtAaoyUtlHl1D3ij1B++KupWcQQ=="
     },
     "@oceanprotocol/typographies": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@oceanprotocol/art": "^3.2.0",
-    "@oceanprotocol/contracts": "^1.1.7",
+    "@oceanprotocol/contracts": "^1.1.8",
     "@oceanprotocol/typographies": "^0.1.0",
     "@svgr/webpack": "^6.5.0",
     "axios": "^1.1.3",


### PR DESCRIPTION
- updates `veFeeEstimate` contract